### PR TITLE
Fix ConcurrentModificationException in GDBackgroundTask.findPOIs

### DIFF
--- a/Source/Platform/Target/Android/mobile/src/main/java/com/untouchableapps/android/geodiscoverer/logic/GDBackgroundTask.kt
+++ b/Source/Platform/Target/Android/mobile/src/main/java/com/untouchableapps/android/geodiscoverer/logic/GDBackgroundTask.kt
@@ -596,6 +596,7 @@ class GDBackgroundTask() : CoroutineScope by MainScope() {
                   limitReached = true
 
                 // Add the found POIs incl. duplicate handling
+                val resultSnapshot = result.toList()
                 for (poi in nearbyPOIs) {
 
                   // Decide on the POI details
@@ -611,7 +612,7 @@ class GDBackgroundTask() : CoroutineScope by MainScope() {
 
                   // Check for duplicates
                   var duplicate = false
-                  for (point in result) {
+                  for (point in resultSnapshot) {
                     if (point.nameOriginal == name) {
                       if ((point.latitude == poi.latitude) && (point.longitude == poi.longitude)) {
                         //GDApplication.addMessage(GDApplication.DEBUG_MSG,"GDApp","POI ${name} already exists in search result")
@@ -629,7 +630,7 @@ class GDBackgroundTask() : CoroutineScope by MainScope() {
                   var count = 2
                   while (!nameIsUnique) {
                     nameIsUnique = true
-                    for (point in result) {
+                    for (point in resultSnapshot) {
                       if (point.nameUniquified == uniqueName) {
                         uniqueName = "${name} ${count}"
                         count++

--- a/Source/Platform/Target/Android/mobile/src/main/java/com/untouchableapps/android/geodiscoverer/logic/GDBackgroundTask.kt
+++ b/Source/Platform/Target/Android/mobile/src/main/java/com/untouchableapps/android/geodiscoverer/logic/GDBackgroundTask.kt
@@ -642,8 +642,8 @@ class GDBackgroundTask() : CoroutineScope by MainScope() {
                     GDApplication.addMessage(GDApplication.DEBUG_MSG,"GDApp","POI ${name} uniquified to ${uniqueName}")
                   }*/
 
-                  // Add the entry
-                  var item = AddressPointItem(
+                  // Add the entry (sort by distance after all POIs are collected)
+                  val item = AddressPointItem(
                     name,
                     uniqueName,
                     distance,
@@ -651,21 +651,14 @@ class GDBackgroundTask() : CoroutineScope by MainScope() {
                     poi.latitude,
                     poi.longitude
                   )
-                  var added = false
-                  for (i in result.indices) {
-                    if (distance < result[i].distanceRaw) {
-                      result.add(i, item)
-                      added = true
-                      break
-                    }
-                  }
-                  if (!added)
-                    result.add(item)
+                  result.add(item)
                 }
               }
             }
             //GDApplication.addMessage(GDApplication.DEBUG_MSG, "GDApp", "POI search finished")
           }
+          // Sort results by distance ascending
+          result.sortBy { it.distanceRaw }
           if (isActive) {
             poiFindLastItemCopy.result = result
             poiFindLastItemCopy.limitReached = limitReached


### PR DESCRIPTION
## Problem

A `ConcurrentModificationException` occurs at `GDBackgroundTask.kt:558` when the `result` list is modified during iteration in `findPOIs`.

## Fix

Take a snapshot of the result list (`val resultSnapshot = result.toList()`) before iterating, so that duplicate and uniquify checks operate on a stable copy.

## Testing

Built successfully with `assembleDebug` for mobile and wear targets.